### PR TITLE
Added eslint, husky, lint-staged, jest workflow.

### DIFF
--- a/__tests__/app.js
+++ b/__tests__/app.js
@@ -15,6 +15,7 @@ describe('generator-bluegenes-tool:app', () => {
       'src/index.js',
       'src/style.less',
       'dev/serve.js',
+      'tests/index.test.js',
       'config.json',
       'demo.html',
       'package.json',

--- a/__tests__/app.js
+++ b/__tests__/app.js
@@ -23,7 +23,8 @@ describe('generator-bluegenes-tool:app', () => {
       'TODO.md',
       '.eslintrc',
       '.eslintignore',
-      '.prettierrc'
+      '.prettierrc',
+      '.gitignore'
     ]);
   });
 });

--- a/__tests__/app.js
+++ b/__tests__/app.js
@@ -20,7 +20,10 @@ describe('generator-bluegenes-tool:app', () => {
       'package.json',
       'README.md',
       'webpack.config.js',
-      'TODO.md'
+      'TODO.md',
+      '.eslintrc',
+      '.eslintignore',
+      '.prettierrc'
     ]);
   });
 });

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -1,4 +1,3 @@
-'use strict';
 const Generator = require('yeoman-generator');
 const chalk = require('chalk');
 const yosay = require('yosay');
@@ -147,6 +146,24 @@ module.exports = class extends Generator {
       {}
     );
 
+    this.fs.copyTpl(
+      this.templatePath('.eslintrc'),
+      this.destinationPath('.eslintrc'),
+      {}
+    );
+
+    this.fs.copyTpl(
+      this.templatePath('.eslintignore'),
+      this.destinationPath('.eslintignore'),
+      {}
+    );
+
+    this.fs.copyTpl(
+      this.templatePath('.prettierrc'),
+      this.destinationPath('.prettierrc'),
+      {}
+    );
+
     this.fs.copyTpl(this.templatePath('TODO.md'), this.destinationPath('TODO.md'), {});
   }
 
@@ -161,7 +178,7 @@ module.exports = class extends Generator {
 
 function stringToMultiValue(values) {
   // Split and trim values. Return pseudo-aray.
-  var vals = values.split(',');
+  let vals = values.split(',');
   // No more whitespace, please
   vals = vals.map(val => val.replace(/\s+/g, ''));
   return JSON.stringify(vals);

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -164,6 +164,12 @@ module.exports = class extends Generator {
       {}
     );
 
+    this.fs.copyTpl(
+      this.templatePath('.gitignore'),
+      this.destinationPath('.gitignore'),
+      {}
+    );
+
     this.fs.copyTpl(this.templatePath('TODO.md'), this.destinationPath('TODO.md'), {});
   }
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -83,6 +83,12 @@ module.exports = class extends Generator {
             name: 'tablerows'
           }
         ]
+      },
+      {
+        type: 'confirm',
+        message: 'Do you require React and babel setup for sugary stuff?',
+        name: 'reactReq',
+        default: false
       }
     ];
     return this.prompt(prompts).then(props => {
@@ -92,13 +98,18 @@ module.exports = class extends Generator {
   }
 
   writing() {
+    // Short way, this update this to `react-setup` if required
+    let reactSetupReq = '';
+    if (this.props.reactReq) reactSetupReq = '.react-setup';
+
     this.fs.copyTpl(this.templatePath('demo.html'), this.destinationPath('demo.html'), {
       title: this.props.toolNameHuman,
       toolNameCljs: this.props.toolNameCljs,
       mineUrl: 'http://www.humanmine.org/human'
     });
+
     this.fs.copyTpl(
-      this.templatePath('webpack.config.js'),
+      this.templatePath(`webpack.config${reactSetupReq}.js`),
       this.destinationPath('webpack.config.js'),
       {
         toolNameCljs: this.props.toolNameCljs
@@ -117,7 +128,7 @@ module.exports = class extends Generator {
     );
 
     this.fs.copyTpl(
-      this.templatePath('package.json'),
+      this.templatePath(`package${reactSetupReq}.json`),
       this.destinationPath('package.json'),
       {
         author: this.props.author,
@@ -143,7 +154,7 @@ module.exports = class extends Generator {
     );
 
     this.fs.copyTpl(
-      this.templatePath('src/index.js'),
+      this.templatePath(`src/index${reactSetupReq}.js`),
       this.destinationPath('src/index.js'),
       {}
     );
@@ -155,7 +166,7 @@ module.exports = class extends Generator {
     );
 
     this.fs.copyTpl(
-      this.templatePath('.eslintrc'),
+      this.templatePath(`.eslintrc${reactSetupReq}`),
       this.destinationPath('.eslintrc'),
       {}
     );
@@ -185,6 +196,18 @@ module.exports = class extends Generator {
     );
 
     this.fs.copyTpl(this.templatePath('TODO.md'), this.destinationPath('TODO.md'), {});
+
+    if (reactSetupReq) {
+      this.fs.copyTpl(
+        this.templatePath('src/RootContainer.react-setup.js'),
+        this.destinationPath('src/RootContainer.js')
+      );
+
+      this.fs.copyTpl(
+        this.templatePath('.babelrc.react-setup'),
+        this.destinationPath('.babelrc')
+      );
+    }
   }
 
   install() {

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -174,6 +174,13 @@ module.exports = class extends Generator {
   }
 
   install() {
+    this.spawnCommandSync('git', ['init']);
+    this.spawnCommandSync('git', ['add', '.']);
+    this.spawnCommandSync('git', [
+      'commit',
+      '-m',
+      'intial commit - scaffolded tool via CLI'
+    ]);
     this.installDependencies({
       npm: true,
       bower: false,

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -22,7 +22,15 @@ module.exports = class extends Generator {
         name: 'toolNameCljs',
         message:
           'What shall we name your project? This is a computer name with no spaces or special characters.',
-        default: 'bluegenesToolNameHere'
+        default: 'bluegenesToolNameHere',
+        validate: input => {
+          input = input.trim();
+          if (input === '') return 'App name cannot be empty!';
+          if (input.search('-') !== -1 || input.search(' ') !== -1) {
+            return 'Oops! Project name cannot contain spaces or special characters!';
+          }
+          return true;
+        }
       },
       {
         type: 'input',

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -170,6 +170,12 @@ module.exports = class extends Generator {
       {}
     );
 
+    this.fs.copyTpl(
+      this.templatePath('tests/index.test.js'),
+      this.destinationPath('tests/index.test.js'),
+      {}
+    );
+
     this.fs.copyTpl(this.templatePath('TODO.md'), this.destinationPath('TODO.md'), {});
   }
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -86,7 +86,8 @@ module.exports = class extends Generator {
       },
       {
         type: 'confirm',
-        message: 'Do you require React and babel setup for sugary stuff?',
+        message:
+          'Initialise with React and Babel? This will allow you to use React and ECMAscript 2015+ features.',
         name: 'reactReq',
         default: false
       }

--- a/generators/app/templates/.babelrc.react-setup
+++ b/generators/app/templates/.babelrc.react-setup
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/generators/app/templates/.babelrc.react-setup
+++ b/generators/app/templates/.babelrc.react-setup
@@ -1,3 +1,4 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"]
+  "presets": ["@babel/preset-env", "@babel/preset-react"],
+  "plugins": ["@babel/plugin-transform-modules-commonjs"]
 }

--- a/generators/app/templates/.babelrc.react-setup
+++ b/generators/app/templates/.babelrc.react-setup
@@ -1,4 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"],
-  "plugins": ["@babel/plugin-transform-modules-commonjs"]
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
 }

--- a/generators/app/templates/.eslintignore
+++ b/generators/app/templates/.eslintignore
@@ -1,0 +1,2 @@
+node_modules/*
+dist/*

--- a/generators/app/templates/.eslintignore
+++ b/generators/app/templates/.eslintignore
@@ -1,2 +1,4 @@
 node_modules/*
 dist/*
+dev/*
+webpack.config.js

--- a/generators/app/templates/.eslintrc
+++ b/generators/app/templates/.eslintrc
@@ -9,6 +9,7 @@
     "prettier"
   ],
   "plugins": [
+    "html",
     "prettier"
   ],
   "parserOptions": {
@@ -30,6 +31,7 @@
 		"semi": [
 			"error",
 			"always"
-		]
+    ],
+    "prettier/prettier": "error"
 	}
 }

--- a/generators/app/templates/.eslintrc
+++ b/generators/app/templates/.eslintrc
@@ -2,7 +2,9 @@
 	"env": {
 		"browser": true,
     "es6": true,
-    "jquery": true
+    "jquery": true,
+    "node": true,
+    "jest": true
 	},
 	"extends": [
     "eslint:recommended",

--- a/generators/app/templates/.eslintrc
+++ b/generators/app/templates/.eslintrc
@@ -1,0 +1,35 @@
+{
+	"env": {
+		"browser": true,
+    "es6": true,
+    "jquery": true
+	},
+	"extends": [
+    "eslint:recommended",
+    "prettier"
+  ],
+  "plugins": [
+    "prettier"
+  ],
+  "parserOptions": {
+    "sourceType": "module"
+  },
+	"rules": {
+		"indent": [
+			"error",
+			"tab"
+		],
+		"linebreak-style": [
+			"error",
+			"unix"
+		],
+		"quotes": [
+			"error",
+			"single"
+		],
+		"semi": [
+			"error",
+			"always"
+		]
+	}
+}

--- a/generators/app/templates/.eslintrc
+++ b/generators/app/templates/.eslintrc
@@ -9,29 +9,18 @@
     "prettier"
   ],
   "plugins": [
-    "html",
+    "import",
     "prettier"
   ],
   "parserOptions": {
     "sourceType": "module"
   },
 	"rules": {
-		"indent": [
-			"error",
-			"tab"
-		],
-		"linebreak-style": [
-			"error",
-			"unix"
-		],
-		"quotes": [
-			"error",
-			"single"
-		],
-		"semi": [
-			"error",
-			"always"
-    ],
-    "prettier/prettier": "error"
-	}
+    "indent": ["error", "tab"],
+		"linebreak-style": ["error", "unix"],
+		"quotes": ["error", "single"],
+		"semi": ["error", "always"],
+    "prettier/prettier": "error",
+    "comma-dangle": ["error", "never"]
+  }
 }

--- a/generators/app/templates/.eslintrc
+++ b/generators/app/templates/.eslintrc
@@ -24,5 +24,10 @@
 		"semi": ["error", "always"],
     "prettier/prettier": "error",
     "comma-dangle": ["error", "never"]
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
   }
 }

--- a/generators/app/templates/.eslintrc.react-setup
+++ b/generators/app/templates/.eslintrc.react-setup
@@ -1,0 +1,30 @@
+{
+	"env": {
+		"browser": true,
+    "es6": true,
+    "jquery": true,
+    "node": true,
+    "jest": true
+	},
+	"extends": [
+    "eslint:recommended",
+		"plugin:react/recommended",
+    "prettier"
+  ],
+  "plugins": [
+    "import",
+    "prettier"
+  ],
+  "parserOptions": {
+    "sourceType": "module"
+  },
+	"rules": {
+    "indent": ["error", "tab"],
+		"linebreak-style": ["error", "unix"],
+		"quotes": ["error", "single"],
+		"semi": ["error", "always"],
+    "prettier/prettier": "error",
+    "comma-dangle": ["error", "never"],
+		"react/prop-types": 0
+  }
+}

--- a/generators/app/templates/.gitignore
+++ b/generators/app/templates/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/generators/app/templates/.gitignore
+++ b/generators/app/templates/.gitignore
@@ -1,1 +1,3 @@
-node_modules
+node_modules/
+dist/
+package-lock.json

--- a/generators/app/templates/.prettierrc
+++ b/generators/app/templates/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "useTabs": true
 }

--- a/generators/app/templates/.prettierrc
+++ b/generators/app/templates/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/generators/app/templates/.prettierrc
+++ b/generators/app/templates/.prettierrc
@@ -1,5 +1,4 @@
 {
   "singleQuote": true,
-  "trailingComma": "all",
   "useTabs": true
 }

--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -29,6 +29,15 @@ Assuming [webpack](https://webpack.js.org/) is installed globally:
 npm run build
 ```
 
+
+##### Applied Coding practices / ESLint Rules:
+- _indent_: use __tab (2 space tab)__ instead of spaces to not get an error.
+- _linebreak-style_: use __\n__ for a newline, if you're on windows, configure it in your editor settings.
+- _quotes_: use __single quote__ instead of double quote.
+- _semi_: use _semi colon_ at end of each statement / expression / function definition.
+- _comma-dangle_: do not use dangling commas i.e. extra comma at the end of object values, function args, etc.). More about this [here](https://eslint.org/docs/rules/comma-dangle).
+- More pre-configured rules from __eslint:recommended__ you must follow to not get errors [here](https://eslint.org/docs/rules/).
+
 ##### Developing:
 Run each of these commands in separate terminals:
 

--- a/generators/app/templates/demo.html
+++ b/generators/app/templates/demo.html
@@ -26,34 +26,38 @@
   <div class="<%= toolNameCljs %>" id='yourDiv' />
   <script>
     window.onload = function() {
-
-      //The element to attach the viewer to. Must be an existing DOM element
-      var elem = document.getElementById("yourDiv"),
-        //InterMine service, including URL and token.
-        imURL = {
-          root: "<%= mineUrl %>"
-          //could include token here too if we had one
-        },
-        //this is an example of data that could be passed to this tool be BlueGenes
-        //in reality (outside the demo) this would be dynamic and not hard-coded
-        // to an ID.
-        dataToInitialiseToolWith = {
-          "class": "Protein",
-          "format": "id",
-          // right now this id corresponds to Human GATA1
-          // this is a bit fragile since IDs change with every build
-          // but we don't want to make the code more complicated than
-          // needed for the demo.
-          "value": 1276963
-        },
-        toolState = null; //to be confirmed how we use this.
-      // THIS LINE IS THE IMPORTANT BIT. YOU SHOULDN'T NEED TO EDIT IT
-      // the method signature should match the signature in src/index.js
-      $.ajax("config.json").then(function(config) {
-        <%= toolNameCljs %>.main(
-          elem, imURL, dataToInitialiseToolWith, toolState, config);
-      });
-    }
+	    //The element to attach the viewer to. Must be an existing DOM element
+    	var elem = document.getElementById('yourDiv'),
+    		//InterMine service, including URL and token.
+    		imURL = {
+    			root: '<%= mineUrl %>',
+    			//could include token here too if we had one
+    		},
+    		//this is an example of data that could be passed to this tool be BlueGenes
+    		//in reality (outside the demo) this would be dynamic and not hard-coded
+    		// to an ID.
+    		dataToInitialiseToolWith = {
+    			class: 'Protein',
+    			format: 'id',
+    			// right now this id corresponds to Human GATA1
+    			// this is a bit fragile since IDs change with every build
+    			// but we don't want to make the code more complicated than
+    			// needed for the demo.
+    			value: 1276963
+    		},
+    		toolState = null; //to be confirmed how we use this.
+    	// THIS LINE IS THE IMPORTANT BIT. YOU SHOULDN'T NEED TO EDIT IT
+    	// the method signature should match the signature in src/index.js
+    	$.ajax('config.json').then(function(config) {
+    		<%= toolNameCljs %>.main(
+    			elem,
+          imURL,
+          dataToInitialiseToolWith,
+          toolState,
+          config,
+        );
+    	});
+    };
   </script>
   <script src="dist/bundle.js"></script>
 

--- a/generators/app/templates/demo.html
+++ b/generators/app/templates/demo.html
@@ -45,7 +45,7 @@
     			// needed for the demo.
     			value: 1276963
     		},
-    		toolState = null; //to be confirmed how we use this.
+    		toolState = {}; //to be confirmed how we use this.
     	// THIS LINE IS THE IMPORTANT BIT. YOU SHOULDN'T NEED TO EDIT IT
     	// the method signature should match the signature in src/index.js
     	$.ajax('config.json').then(function(config) {

--- a/generators/app/templates/demo.html
+++ b/generators/app/templates/demo.html
@@ -49,7 +49,7 @@
     	// THIS LINE IS THE IMPORTANT BIT. YOU SHOULDN'T NEED TO EDIT IT
     	// the method signature should match the signature in src/index.js
     	$.ajax('config.json').then(function(config) {
-    		<%= toolNameCljs %>(
+    		<%= toolNameCljs %>.main(
     			elem,
           imURL,
           dataToInitialiseToolWith,

--- a/generators/app/templates/demo.html
+++ b/generators/app/templates/demo.html
@@ -49,7 +49,7 @@
     	// THIS LINE IS THE IMPORTANT BIT. YOU SHOULDN'T NEED TO EDIT IT
     	// the method signature should match the signature in src/index.js
     	$.ajax('config.json').then(function(config) {
-    		<%= toolNameCljs %>.default(
+    		<%= toolNameCljs %>(
     			elem,
           imURL,
           dataToInitialiseToolWith,

--- a/generators/app/templates/demo.html
+++ b/generators/app/templates/demo.html
@@ -49,7 +49,7 @@
     	// THIS LINE IS THE IMPORTANT BIT. YOU SHOULDN'T NEED TO EDIT IT
     	// the method signature should match the signature in src/index.js
     	$.ajax('config.json').then(function(config) {
-    		<%= toolNameCljs %>.main(
+    		<%= toolNameCljs %>.default(
     			elem,
           imURL,
           dataToInitialiseToolWith,

--- a/generators/app/templates/demo.html
+++ b/generators/app/templates/demo.html
@@ -19,7 +19,13 @@
 
   <!-- These are the styles YOU implement in src/style.less -->
   <link rel="stylesheet" href="dist/style.css">
-
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.2.0/socket.io.js"></script>
+	<script>
+		var socket = io("http://localhost:3457");
+    socket.on('reload', function(){
+			document.location.reload();
+    });
+	</script>
 </head>
 
 <body>

--- a/generators/app/templates/dev/serve.js
+++ b/generators/app/templates/dev/serve.js
@@ -9,7 +9,5 @@ app.use(serveStatic('./', {
 }));
 app.listen(port);
 
-console.log("Listening on port " + port);
-console.log("Visit http://localhost:" +
-  port +
-  " to view your test application");
+console.log('Listening on port ' + port);
+console.log('Visit http://localhost:' + port + ' to view your test application');

--- a/generators/app/templates/dev/serve.js
+++ b/generators/app/templates/dev/serve.js
@@ -1,8 +1,31 @@
 var express = require('express');
 var serveStatic = require('serve-static');
+var chokidar = require('chokidar');
+var spawnCommand = require('child_process').spawnSync;
 var port = 3456;
 
+var io = require('socket.io')(3457);
 var app = express();
+
+var watcher = chokidar.watch('src');
+watcher.on('all', (eventName, path) => {
+	if (eventName === 'addDir') {
+		console.log('Building files...');
+		spawnCommand('npm', ['run', 'less']);
+		spawnCommand('npm', ['run', 'build']);
+		console.log('Files built!');
+	} else if (eventName === 'add') return;
+	else if (eventName === 'change') {
+		console.log('Building files...');
+		if (path.search('.less') !== -1) {
+			spawnCommand('npm', ['run', 'less']);
+		} else {
+			spawnCommand('npm', ['run', 'build']);
+		}
+		io.emit('reload');
+		console.log('Reloaded!');
+	}
+});
 
 app.use(serveStatic('./', {
   'index': ['demo.html']

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -10,8 +10,9 @@
 		"server": "node dev/serve.js",
 		"dev": "./node_modules/.bin/webpack --watch",
 		"less": "lessc src/style.less dist/style.css --clean-css",
-		"lint": "./node_modules/.bin/eslint . -c .eslintrc --ext js,html",
-		"lint:fix": "./node_modules/.bin/eslint . -c .eslintrc --ext js,html --fix"
+		"lint": "./node_modules/.bin/eslint src/*.js -c .eslintrc --ext js",
+		"lint:fix":
+			"./node_modules/.bin/eslint src/*.js -c .eslintrc --ext js --fix"
 	},
 	"husky": {
 		"hooks": {
@@ -29,7 +30,6 @@
 	"devDependencies": {
 		"eslint": "^5.16.0",
 		"eslint-config-prettier": "^4.2.0",
-		"eslint-plugin-html": "^5.0.3",
 		"eslint-plugin-import": "^2.17.2",
 		"eslint-plugin-prettier": "^3.1.0",
 		"express": "^4.16.3",

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -7,22 +7,27 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "./node_modules/.bin/webpack",
-    "server" : "node dev/serve.js",
+    "server": "node dev/serve.js",
     "dev": "./node_modules/.bin/webpack --watch",
-    "less": "lessc src/style.less dist/style.css --clean-css"
+    "less": "lessc src/style.less dist/style.css --clean-css",
+    "lint": "./node_modules/.bin/eslint . -c .eslintrc --ext js,html",
+    "lint:fix": "./node_modules/.bin/eslint . -c .eslintrc --ext js,html --fix"
   },
-  "keywords": [
-    "bluegenes-intermine-tool"
-  ],
+  "keywords": ["bluegenes-intermine-tool"],
   "author": "<%= author %>",
   "license": "<%= licence %>",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
+    "eslint": "^5.16.0",
+    "eslint-config-prettier": "^4.2.0",
+    "eslint-plugin-html": "^5.0.3",
+    "eslint-plugin-import": "^2.17.2",
+    "eslint-plugin-prettier": "^3.1.0",
     "express": "^4.16.3",
     "imjs": "^3.16",
     "less": "^3.8.1",
     "less-plugin-clean-css": "^1.5.1",
+    "prettier": "^1.17.0",
     "webpack": "^4.16.5",
     "webpack-cli": "^3.1.0"
   }

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -10,6 +10,8 @@
 		"server": "node dev/serve.js",
 		"dev": "./node_modules/.bin/webpack --watch",
 		"less": "lessc src/style.less dist/style.css --clean-css",
+		"less:dev":
+			"./node_modules/less-watch-compiler/dist/less-watch-compiler.js src dist",
 		"lint": "./node_modules/.bin/eslint src/*.js -c .eslintrc --ext js",
 		"lint:fix":
 			"./node_modules/.bin/eslint src/*.js -c .eslintrc --ext js --fix"
@@ -37,6 +39,7 @@
 		"imjs": "^3.16",
 		"jest": "^24.8.0",
 		"less": "^3.8.1",
+		"less-watch-compiler": "^1.13.0",
 		"less-plugin-clean-css": "^1.5.1",
 		"lint-staged": "^8.1.6",
 		"prettier": "^1.17.0",

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -1,34 +1,45 @@
 {
-  "name": "@intermine/<%=toolNameNpm%>",
-  "version": "1.0.0",
-  "main": "src/index.js",
-  "description": "",
-  "homepage": "http://www.intermine.org",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "./node_modules/.bin/webpack",
-    "server": "node dev/serve.js",
-    "dev": "./node_modules/.bin/webpack --watch",
-    "less": "lessc src/style.less dist/style.css --clean-css",
-    "lint": "./node_modules/.bin/eslint . -c .eslintrc --ext js,html",
-    "lint:fix": "./node_modules/.bin/eslint . -c .eslintrc --ext js,html --fix"
-  },
-  "keywords": ["bluegenes-intermine-tool"],
-  "author": "<%= author %>",
-  "license": "<%= licence %>",
-  "dependencies": {},
-  "devDependencies": {
-    "eslint": "^5.16.0",
-    "eslint-config-prettier": "^4.2.0",
-    "eslint-plugin-html": "^5.0.3",
-    "eslint-plugin-import": "^2.17.2",
-    "eslint-plugin-prettier": "^3.1.0",
-    "express": "^4.16.3",
-    "imjs": "^3.16",
-    "less": "^3.8.1",
-    "less-plugin-clean-css": "^1.5.1",
-    "prettier": "^1.17.0",
-    "webpack": "^4.16.5",
-    "webpack-cli": "^3.1.0"
-  }
+	"name": "@intermine/<%=toolNameNpm%>",
+	"version": "1.0.0",
+	"main": "src/index.js",
+	"description": "",
+	"homepage": "http://www.intermine.org",
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1",
+		"build": "./node_modules/.bin/webpack",
+		"server": "node dev/serve.js",
+		"dev": "./node_modules/.bin/webpack --watch",
+		"less": "lessc src/style.less dist/style.css --clean-css",
+		"lint": "./node_modules/.bin/eslint . -c .eslintrc --ext js,html",
+		"lint:fix": "./node_modules/.bin/eslint . -c .eslintrc --ext js,html --fix"
+	},
+	"husky": {
+		"hooks": {
+			"pre-commit": "lint-staged",
+			"pre-push": "npm test"
+		}
+	},
+	"lint-staged": {
+		"*.js": ["./node_modules/.bin/eslint -c .eslintrc", "git add"]
+	},
+	"keywords": ["bluegenes-intermine-tool"],
+	"author": "<%= author %>",
+	"license": "<%= licence %>",
+	"dependencies": {},
+	"devDependencies": {
+		"eslint": "^5.16.0",
+		"eslint-config-prettier": "^4.2.0",
+		"eslint-plugin-html": "^5.0.3",
+		"eslint-plugin-import": "^2.17.2",
+		"eslint-plugin-prettier": "^3.1.0",
+		"express": "^4.16.3",
+		"husky": "^2.2.0",
+		"imjs": "^3.16",
+		"less": "^3.8.1",
+		"less-plugin-clean-css": "^1.5.1",
+		"lint-staged": "^8.1.6",
+		"prettier": "^1.17.0",
+		"webpack": "^4.16.5",
+		"webpack-cli": "^3.1.0"
+	}
 }

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -7,8 +7,8 @@
 	"scripts": {
 		"test": "jest",
 		"build": "./node_modules/.bin/webpack",
-		"server": "node dev/serve.js",
-		"dev": "./node_modules/.bin/webpack --watch",
+		"dev": "node dev/serve.js",
+		"webpack:watch": "./node_modules/.bin/webpack --watch",
 		"less": "lessc src/style.less dist/style.css --clean-css",
 		"less:dev":
 			"./node_modules/less-watch-compiler/dist/less-watch-compiler.js src dist",
@@ -30,6 +30,7 @@
 	"license": "<%= licence %>",
 	"dependencies": {},
 	"devDependencies": {
+		"chokidar": "^3.0.0",
 		"eslint": "^5.16.0",
 		"eslint-config-prettier": "^4.2.0",
 		"eslint-plugin-import": "^2.17.2",
@@ -43,6 +44,7 @@
 		"less-plugin-clean-css": "^1.5.1",
 		"lint-staged": "^8.1.6",
 		"prettier": "^1.17.0",
+		"socket.io": "^2.2.0",
 		"webpack": "^4.16.5",
 		"webpack-cli": "^3.1.0"
 	}

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -5,7 +5,7 @@
 	"description": "",
 	"homepage": "http://www.intermine.org",
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1",
+		"test": "jest",
 		"build": "./node_modules/.bin/webpack",
 		"server": "node dev/serve.js",
 		"dev": "./node_modules/.bin/webpack --watch",
@@ -35,6 +35,7 @@
 		"express": "^4.16.3",
 		"husky": "^2.2.0",
 		"imjs": "^3.16",
+		"jest": "^24.8.0",
 		"less": "^3.8.1",
 		"less-plugin-clean-css": "^1.5.1",
 		"lint-staged": "^8.1.6",

--- a/generators/app/templates/package.react-setup.json
+++ b/generators/app/templates/package.react-setup.json
@@ -1,0 +1,54 @@
+{
+	"name": "@intermine/<%=toolNameNpm%>",
+	"version": "1.0.0",
+	"main": "src/index.js",
+	"description": "",
+	"homepage": "http://www.intermine.org",
+	"scripts": {
+		"test": "jest",
+		"build": "./node_modules/.bin/webpack",
+		"server": "node dev/serve.js",
+		"dev": "./node_modules/.bin/webpack --watch",
+		"less": "lessc src/style.less dist/style.css --clean-css",
+		"lint": "./node_modules/.bin/eslint src/*.js -c .eslintrc --ext js",
+		"lint:fix":
+			"./node_modules/.bin/eslint src/*.js -c .eslintrc --ext js --fix"
+	},
+	"husky": {
+		"hooks": {
+			"pre-commit": "lint-staged",
+			"pre-push": "npm test"
+		}
+	},
+	"lint-staged": {
+		"*.js": ["./node_modules/.bin/eslint -c .eslintrc", "git add"]
+	},
+	"keywords": ["bluegenes-intermine-tool"],
+	"author": "<%= author %>",
+	"license": "<%= licence %>",
+	"dependencies": {
+		"react": "^16.8.6",
+		"react-dom": "^16.8.6"
+	},
+	"devDependencies": {
+		"@babel/core": "^7.4.4",
+		"@babel/preset-env": "^7.4.4",
+		"@babel/preset-react": "^7.0.0",
+		"babel-loader": "^8.0.6",
+		"eslint": "^5.16.0",
+		"eslint-config-prettier": "^4.2.0",
+		"eslint-plugin-import": "^2.17.2",
+		"eslint-plugin-prettier": "^3.1.0",
+		"eslint-plugin-react": "^7.13.0",
+		"express": "^4.16.3",
+		"husky": "^2.2.0",
+		"imjs": "^3.16",
+		"jest": "^24.8.0",
+		"less": "^3.8.1",
+		"less-plugin-clean-css": "^1.5.1",
+		"lint-staged": "^8.1.6",
+		"prettier": "^1.17.0",
+		"webpack": "^4.16.5",
+		"webpack-cli": "^3.1.0"
+	}
+}

--- a/generators/app/templates/package.react-setup.json
+++ b/generators/app/templates/package.react-setup.json
@@ -32,6 +32,7 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.4.4",
+		"@babel/plugin-transform-modules-commonjs": "^7.4.4",
 		"@babel/preset-env": "^7.4.4",
 		"@babel/preset-react": "^7.0.0",
 		"babel-loader": "^8.0.6",

--- a/generators/app/templates/package.react-setup.json
+++ b/generators/app/templates/package.react-setup.json
@@ -32,7 +32,6 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.4.4",
-		"@babel/plugin-transform-modules-commonjs": "^7.4.4",
 		"@babel/preset-env": "^7.4.4",
 		"@babel/preset-react": "^7.0.0",
 		"babel-loader": "^8.0.6",

--- a/generators/app/templates/package.react-setup.json
+++ b/generators/app/templates/package.react-setup.json
@@ -7,8 +7,8 @@
 	"scripts": {
 		"test": "jest",
 		"build": "./node_modules/.bin/webpack",
-		"server": "node dev/serve.js",
-		"dev": "./node_modules/.bin/webpack --watch",
+		"dev": "node dev/serve.js",
+		"webpack:watch": "./node_modules/.bin/webpack --watch",
 		"less": "lessc src/style.less dist/style.css --clean-css",
 		"lint": "./node_modules/.bin/eslint src/*.js -c .eslintrc --ext js",
 		"lint:fix":
@@ -35,6 +35,7 @@
 		"@babel/preset-env": "^7.4.4",
 		"@babel/preset-react": "^7.0.0",
 		"babel-loader": "^8.0.6",
+		"chokidar": "^3.0.0",
 		"eslint": "^5.16.0",
 		"eslint-config-prettier": "^4.2.0",
 		"eslint-plugin-import": "^2.17.2",
@@ -48,6 +49,7 @@
 		"less-plugin-clean-css": "^1.5.1",
 		"lint-staged": "^8.1.6",
 		"prettier": "^1.17.0",
+		"socket.io": "^2.2.0",
 		"webpack": "^4.16.5",
 		"webpack-cli": "^3.1.0"
 	}

--- a/generators/app/templates/src/RootContainer.react-setup.js
+++ b/generators/app/templates/src/RootContainer.react-setup.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+class RootContainer extends React.Component {
+	render() {
+		return (
+			<div className="rootContainer">
+				<h1>Your Data Viz Here</h1>
+			</div>
+		);
+	}
+}
+
+export default RootContainer;

--- a/generators/app/templates/src/index.js
+++ b/generators/app/templates/src/index.js
@@ -2,7 +2,8 @@
 // const SomePackage = require('PackageName');
 
 // make sure to export main, with the signature
-function main(el, service, imEntity, state = {}, config) {
+function main(el, service, imEntity, state, config) {
+  if (!state) state = {};
 	if (!el || !service || !imEntity || !state || !config) {
 		throw new Error('Call main with correct signature');
 	}

--- a/generators/app/templates/src/index.js
+++ b/generators/app/templates/src/index.js
@@ -1,5 +1,5 @@
 // add any imports if needed, or write your script directly in this file.
-// import SomePackage from "PackageName";
+// const SomePackage = require('PackageName');
 
 // make sure to export main, with the signature
 function main(el, service, imEntity, state, config) {
@@ -24,6 +24,11 @@ function main(el, service, imEntity, state, config) {
     });
 
   */
+	el.innerHTML = `
+		<div class="rootContainer">
+			<h1>Your Data Viz Here</h1>
+		</div>
+	`;
 }
 
-module.exports = { main };
+module.exports.default = main;

--- a/generators/app/templates/src/index.js
+++ b/generators/app/templates/src/index.js
@@ -2,7 +2,7 @@
 // const SomePackage = require('PackageName');
 
 // make sure to export main, with the signature
-function main(el, service, imEntity, state, config) {
+function main(el, service, imEntity, state = {}, config) {
 	if (!el || !service || !imEntity || !state || !config) {
 		throw new Error('Call main with correct signature');
 	}

--- a/generators/app/templates/src/index.js
+++ b/generators/app/templates/src/index.js
@@ -31,4 +31,4 @@ function main(el, service, imEntity, state = {}, config) {
 	`;
 }
 
-module.exports = main;
+module.exports = { main };

--- a/generators/app/templates/src/index.js
+++ b/generators/app/templates/src/index.js
@@ -1,18 +1,17 @@
-//add any imports if needed, or write your script directly in this file.
-//import SomePackage from "PackageName";
+// add any imports if needed, or write your script directly in this file.
+// import SomePackage from "PackageName";
 
-//make sure to export main, with the signature
-export function main (el, service, imEntity, state, config) {
-    // sample code here to convert the provided intermine object (e.g. perhaps
-    // an id) into an identifier the tool expects. e.g.:
-    // of course if your tool was built for intermine it might understand
-    // intermine ids already, but many others tools expect a gene symbol or
-    // protein accession, etc...
+// make sure to export main, with the signature
+export function main(/*el, service, imEntity, state, config*/) {
+	// sample code here to convert the provided intermine object (e.g. perhaps
+	// an id) into an identifier the tool expects. e.g.:
+	// of course if your tool was built for intermine it might understand
+	// intermine ids already, but many others tools expect a gene symbol or
+	// protein accession, etc...
+	/**
+   * Example - you can delete this and replace with your own code *******
 
-/***************************************************************************
-/****** Example - you can delete this and replace with your own code *******
-
-    //protVista expects an accession, so convert intermine id to accession
+    // protVista expects an accession, so convert intermine id to accession
 
     var columnToConvert = config.columnMapping[imEntity.class][imEntity.format];
     var accession = new imjs.Service(service)
@@ -21,6 +20,5 @@ export function main (el, service, imEntity, state, config) {
         //put some code here to initialise your tool.
     });
 
-******* End Example *****************************************************
-***************************************************************************/
+  */
 }

--- a/generators/app/templates/src/index.js
+++ b/generators/app/templates/src/index.js
@@ -31,4 +31,4 @@ function main(el, service, imEntity, state = {}, config) {
 	`;
 }
 
-module.exports.default = main;
+module.exports = main;

--- a/generators/app/templates/src/index.js
+++ b/generators/app/templates/src/index.js
@@ -2,7 +2,10 @@
 // import SomePackage from "PackageName";
 
 // make sure to export main, with the signature
-export function main(/*el, service, imEntity, state, config*/) {
+function main(el, service, imEntity, state, config) {
+	if (!el || !service || !imEntity || !state || !config) {
+		throw new Error('Call main with correct signature');
+	}
 	// sample code here to convert the provided intermine object (e.g. perhaps
 	// an id) into an identifier the tool expects. e.g.:
 	// of course if your tool was built for intermine it might understand
@@ -22,3 +25,5 @@ export function main(/*el, service, imEntity, state, config*/) {
 
   */
 }
+
+module.exports = { main };

--- a/generators/app/templates/src/index.react-setup.js
+++ b/generators/app/templates/src/index.react-setup.js
@@ -17,4 +17,4 @@ function main(el, service, imEntity, state = {}, config) {
 	);
 }
 
-module.exports = main;
+export { main };

--- a/generators/app/templates/src/index.react-setup.js
+++ b/generators/app/templates/src/index.react-setup.js
@@ -17,4 +17,4 @@ function main(el, service, imEntity, state = {}, config) {
 	);
 }
 
-export default main;
+module.exports = main;

--- a/generators/app/templates/src/index.react-setup.js
+++ b/generators/app/templates/src/index.react-setup.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import RootContainer from './RootContainer';
+
+// make sure to export main, with the signature
+function main(el, service, imEntity, state, config) {
+	if (!el || !service || !imEntity || !state || !config) {
+		throw new Error('Call main with correct signature');
+	}
+	ReactDOM.render(
+		<RootContainer
+			serviceUrl={service.root}
+			entity={imEntity}
+			config={config}
+		/>,
+		el
+	);
+}
+
+export default main;

--- a/generators/app/templates/src/index.react-setup.js
+++ b/generators/app/templates/src/index.react-setup.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import RootContainer from './RootContainer';
 
 // make sure to export main, with the signature
-function main(el, service, imEntity, state, config) {
+function main(el, service, imEntity, state = {}, config) {
 	if (!el || !service || !imEntity || !state || !config) {
 		throw new Error('Call main with correct signature');
 	}

--- a/generators/app/templates/src/style.less
+++ b/generators/app/templates/src/style.less
@@ -5,8 +5,11 @@
 
   // If you want to learn more about LESS, visit lesscss.org.
 
-  //to build your css, run `lessc src/style.css dist/style.css --clean-css`
+  // to build your css, run `lessc src/style.css dist/style.css --clean-css`
   // in your terminal
+
+
+  // this is just an example class for root div element, you may modify or delete it as per your usecase
 	.rootContainer {
 		border: 1px solid black;
 		padding: 20px;

--- a/generators/app/templates/src/style.less
+++ b/generators/app/templates/src/style.less
@@ -7,5 +7,8 @@
 
   //to build your css, run `lessc src/style.css dist/style.css --clean-css`
   // in your terminal
-
+	.rootContainer {
+		border: 1px solid black;
+		padding: 20px;
+	}
 }

--- a/generators/app/templates/tests/index.test.js
+++ b/generators/app/templates/tests/index.test.js
@@ -1,4 +1,4 @@
-const main = require('../src').main;
+const main = require('../src').default;
 
 // Example
 describe('main', () => {

--- a/generators/app/templates/tests/index.test.js
+++ b/generators/app/templates/tests/index.test.js
@@ -1,0 +1,11 @@
+const main = require('../src').main;
+
+// Example
+describe('main', () => {
+	test('should throw error when called with wrong signature', () => {
+		expect(() => {
+      // testing with all falsy values
+			main('', 0, null, undefined, []);
+		}).toThrowError('Call main with correct signature');
+	});
+});

--- a/generators/app/templates/tests/index.test.js
+++ b/generators/app/templates/tests/index.test.js
@@ -1,4 +1,4 @@
-const main = require('../src').default;
+const main = require('../src').main;
 
 // Example
 describe('main', () => {

--- a/generators/app/templates/webpack.config.react-setup.js
+++ b/generators/app/templates/webpack.config.react-setup.js
@@ -1,0 +1,27 @@
+const path = require('path');
+const webpack = require('webpack'); //to access built-in plugins
+
+module.exports = {
+  mode: "production",
+  entry: './src/index.js',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+    library: "<%= toolNameCljs %>",
+    libraryTarget: "var"
+  },
+  optimization: {
+    minimize: true
+	},
+	module: {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        use: {
+          loader: "babel-loader"
+        }
+      }
+    ]
+  }
+};

--- a/package.json
+++ b/package.json
@@ -8,14 +8,9 @@
     "email": "yo@intermine.org",
     "url": "http://yo-yehudi.com"
   },
-  "files": [
-    "generators"
-  ],
+  "files": ["generators"],
   "main": "generators/index.js",
-  "keywords": [
-    "bluegenes-tools-generator",
-    "yeoman-generator"
-  ],
+  "keywords": ["bluegenes-tools-generator", "yeoman-generator"],
   "devDependencies": {
     "yeoman-test": "^1.7.0",
     "yeoman-assert": "^3.1.0",
@@ -45,23 +40,14 @@
     "prepublishOnly": "nsp check",
     "pretest": "eslint .",
     "precommit": "lint-staged",
-    "test": "jest"
+    "test": "jest __tests__"
   },
   "lint-staged": {
-    "*.js": [
-      "eslint --fix",
-      "git add"
-    ],
-    "*.json": [
-      "prettier --write",
-      "git add"
-    ]
+    "*.js": ["eslint --fix", "git add"],
+    "*.json": ["prettier --write", "git add"]
   },
   "eslintConfig": {
-    "extends": [
-      "xo",
-      "prettier"
-    ],
+    "extends": ["xo", "prettier"],
     "env": {
       "jest": true,
       "node": true
@@ -75,9 +61,7 @@
         }
       ]
     },
-    "plugins": [
-      "prettier"
-    ]
+    "plugins": ["prettier"]
   },
   "repository": "intermine/generator-bluegenes-tool",
   "license": "MIT"


### PR DESCRIPTION
Updates in this PR:

- Added and setup eslint to the generator template and fixed existing eslint errors in different files
- Setup Husky, Lint-Staged to report error before bad commits
- We now also initialise a git repo and do an initial commit to the generated project
- Jest is setup with a mock test written under `tests/index.test.js`
- Fixes #8 
- Adds on-demand setup of React and sugary javascript - Closes #9 
- Adds support for rebuilding less files while developing - Closes #10 
- Added single command - `npm run dev` which builds and sets up everything. No need to open multiple terminal windows and run multiple commands now. Browser window in which tool is open automatically reloads now when webpack or less is done building. - Closes #11 