### PR TITLE
added optional CSS support

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -110,8 +110,21 @@ module.exports = class extends Generator {
   writing() {
     // Short way, this update this to `react-setup` if required
     let reactSetupReq = '';
+    let CSSLoader = '';
+    let CSSLoaderDependency = '';
     if (this.props.reactReq) {
       reactSetupReq = '.react-setup';
+    }
+    if (this.props.cssLoaderReq) {
+      /* eslint-disable */
+      CSSLoader = `{
+        test: /\.css$/i,
+        use: ["style-loader", "css-loader"]
+      },`;
+      /* eslint-enable */
+      CSSLoaderDependency = `,
+        "style-loader": "^1.1.3",
+        "css-loader": "^3.4.2"`;
     }
 
     this.fs.copyTpl(this.templatePath('demo.html'), this.destinationPath('demo.html'), {
@@ -125,7 +138,8 @@ module.exports = class extends Generator {
       this.templatePath(`webpack.config${reactSetupReq}.js`),
       this.destinationPath('webpack.config.js'),
       {
-        toolNameCljs: this.props.toolNameCljs
+        toolNameCljs: this.props.toolNameCljs,
+        CSSLoader
       }
     );
 
@@ -146,7 +160,8 @@ module.exports = class extends Generator {
       {
         author: this.props.author,
         toolNameNpm: this.props.toolNameNpm,
-        licence: this.props.licence
+        licence: this.props.licence,
+        CSSLoaderDependency
       }
     );
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -115,7 +115,7 @@ module.exports = class extends Generator {
     if (this.props.reactReq) {
       reactSetupReq = '.react-setup';
     }
-    if (this.props.cssLoaderReq) {
+    if (this.props.CSSLoaderReq) {
       /* eslint-disable */
       CSSLoader = `{
         test: /\.css$/i,
@@ -123,8 +123,8 @@ module.exports = class extends Generator {
       },`;
       /* eslint-enable */
       CSSLoaderDependency = `,
-        "style-loader": "^1.1.3",
-        "css-loader": "^3.4.2"`;
+      "style-loader": "^1.1.3",
+      "css-loader": "^3.4.2"`;
     }
 
     this.fs.copyTpl(this.templatePath('demo.html'), this.destinationPath('demo.html'), {

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -25,7 +25,9 @@ module.exports = class extends Generator {
         default: 'bluegenesToolNameHere',
         validate: input => {
           input = input.trim();
-          if (input === '') return 'App name cannot be empty!';
+          if (input === '') {
+            return 'App name cannot be empty!';
+          }
           if (input.search('-') !== -1 || input.search(' ') !== -1) {
             return 'Oops! Project name cannot contain spaces or special characters!';
           }
@@ -90,6 +92,13 @@ module.exports = class extends Generator {
           'Initialise with React and Babel? This will allow you to use React and ECMAscript 2015+ features.',
         name: 'reactReq',
         default: false
+      },
+      {
+        type: 'confirm',
+        message:
+          'Would you like to add CSS-loader to your tool? It would allow you to import css files along with less in your components',
+        name: 'CSSLoaderReq',
+        default: false
       }
     ];
     return this.prompt(prompts).then(props => {
@@ -101,7 +110,9 @@ module.exports = class extends Generator {
   writing() {
     // Short way, this update this to `react-setup` if required
     let reactSetupReq = '';
-    if (this.props.reactReq) reactSetupReq = '.react-setup';
+    if (this.props.reactReq) {
+      reactSetupReq = '.react-setup';
+    }
 
     this.fs.copyTpl(this.templatePath('demo.html'), this.destinationPath('demo.html'), {
       title: this.props.toolNameHuman,

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -48,6 +48,6 @@
 		"prettier": "^1.17.0",
 		"socket.io": "^2.2.0",
 		"webpack": "^4.16.5",
-		"webpack-cli": "^3.1.0"
+		"webpack-cli": "^3.1.0"<%- CSSLoaderDependency %>
 	}
 }

--- a/generators/app/templates/package.react-setup.json
+++ b/generators/app/templates/package.react-setup.json
@@ -53,6 +53,6 @@
 		"prettier": "^1.17.0",
 		"socket.io": "^2.2.0",
 		"webpack": "^4.16.5",
-		"webpack-cli": "^3.1.0"
+		"webpack-cli": "^3.1.0"<%- CSSLoaderDependency %>
 	}
 }

--- a/generators/app/templates/webpack.config.js
+++ b/generators/app/templates/webpack.config.js
@@ -12,5 +12,10 @@ module.exports = {
   },
   optimization: {
     minimize: true
+  },
+  module: {
+    rules: [
+      <%- CSSLoader %>
+    ]
   }
 };

--- a/generators/app/templates/webpack.config.react-setup.js
+++ b/generators/app/templates/webpack.config.react-setup.js
@@ -15,6 +15,7 @@ module.exports = {
 	},
 	module: {
     rules: [
+      <%- CSSLoader %>
       {
         test: /\.(js|jsx)$/,
         exclude: /node_modules/,


### PR DESCRIPTION
Added prompt to ask for the addition of CSS loader. Generating the file _(that needs to be changed)_  by taking the template and passing CSS loader config to webpack file and its dependency to package.json file as per the request and used this `<%= {variable}%>` notation to inject values into the file.
Users can now use css along with less files as per convenience.
Tested it by scaffolding both react and vanilla JS projects.
Fixed #20 